### PR TITLE
Create local.json template

### DIFF
--- a/local.json
+++ b/local.json
@@ -1,0 +1,8 @@
+{
+  "admins": [
+    {
+      "username": "admin",
+      "password": "{{adminPassword}}"
+    }
+  ]
+}


### PR DESCRIPTION
When following the demo instructions [here](https://empirica.ly/docs/room-assignment), users may get confused when the instructions refer to a `local.json` file that does not exist in the directory. this PR creates a template.